### PR TITLE
op3: Claim pro audio feature \o/

### DIFF
--- a/audio/audio_platform_info.xml
+++ b/audio/audio_platform_info.xml
@@ -34,7 +34,7 @@
         <device name="SND_DEVICE_IN_SPEAKER_DMIC_AEC_NS" acdb_id="43" />
         <device name="SND_DEVICE_IN_HEADSET_MIC_FLUENCE" acdb_id="16" />
         <device name="SND_DEVICE_IN_VOICE_HEADSET_MIC" acdb_id="16" />
-        <device name="SND_DEVICE_IN_HEADSET_MIC" acdb_id="23" />
+        <device name="SND_DEVICE_IN_HEADSET_MIC" acdb_id="8" />
         <device name="SND_DEVICE_OUT_HEADPHONES" acdb_id="26" />
     </acdb_ids>
     <bit_width_configs>

--- a/device.mk
+++ b/device.mk
@@ -27,6 +27,8 @@ DEVICE_PACKAGE_OVERLAYS += $(LOCAL_PATH)/overlay
 
 # Permissions
 PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.hardware.audio.low_latency.xml:system/etc/permissions/android.hardware.audio.low_latency.xml \
+    frameworks/native/data/etc/android.hardware.audio.pro.xml:system/etc/permissions/android.hardware.audio.pro.xml \
     frameworks/native/data/etc/android.hardware.bluetooth_le.xml:system/etc/permissions/android.hardware.bluetooth_le.xml \
     frameworks/native/data/etc/android.hardware.bluetooth.xml:system/etc/permissions/android.hardware.bluetooth.xml \
     frameworks/native/data/etc/android.hardware.camera.flash-autofocus.xml:system/etc/permissions/android.hardware.camera.flash-autofocus.xml \

--- a/system.prop
+++ b/system.prop
@@ -22,8 +22,8 @@ audio.dolby.ds2.hardbypass=false
 audio.offload.passthrough=false
 audio.offload.multiple.enabled=true
 audio.offload.min.duration.secs=30
-af.fast_track_multiplier=2
-audio_hal.period_size=192
+af.fast_track_multiplier=1
+audio_hal.period_size=160
 
 # Bluetooth
 bt.max.hfpclient.connections=1


### PR DESCRIPTION
 * Adjust headset mic path to ACDB ID 8. ID 23 is a noise cancelling
   path and has triple the latency. It's likely that ID 23 is to be
   used for VOIP, but needs investigation.
 * Add audio.low_latency and audio.pro flags after achieving consistent
   16ms latency on the headset loopback path.

Change-Id: I22e93675ba69887c7e768393238055872afebc6f